### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "urls": [
+    ["tmp117timod.py", "github:octaprog7/TMP117/tmp117timod.py"],
+    ["sensor_pack_2/__init__.py", "github:octaprog7/TMP117/sensor_pack_2/__init__.py"],
+    ["sensor_pack_2/base_sensor.py", "github:octaprog7/TMP117/sensor_pack_2/base_sensor.py"],
+    ["sensor_pack_2/bus_service.py", "github:octaprog7/TMP117/sensor_pack_2/bus_service.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the TMP117 temperature sensor driver modules.